### PR TITLE
Changed rowheight to fix treeview on Linux

### DIFF
--- a/OpenBatteryInformation/modules/makita_lxt.py
+++ b/OpenBatteryInformation/modules/makita_lxt.py
@@ -124,10 +124,13 @@ class ModuleApplication(tk.Frame):
 
         self.tree = ttk.Treeview(
             tree_frame, 
-            columns=("Value"), 
+            columns=("Value"),
             yscrollcommand=tree_scroll_y.set,
         )
-        
+
+        s = ttk.Style()
+        s.configure('Treeview', rowheight=40)
+                
         tree_scroll_y.config(command=self.tree.yview)
 
         self.tree.heading("#0", text="Parameter")


### PR DESCRIPTION
The treeview on Linux had too narrow rows, this is a quick fix. Not sure if the value is right for other platforms or what's the right way to avoid this problem