### PR TITLE
adding foreground colour to stop white on white text in OSX dark mode

### DIFF
--- a/OpenBatteryInformation/modules/makita_lxt.py
+++ b/OpenBatteryInformation/modules/makita_lxt.py
@@ -133,8 +133,8 @@ class ModuleApplication(tk.Frame):
         self.tree.heading("#0", text="Parameter")
         self.tree.heading("Value", text="Value")
 
-        self.tree.tag_configure('evenrow', background='lightgrey')
-        self.tree.tag_configure('oddrow', background='white')
+        self.tree.tag_configure('evenrow', background='lightgrey', foreground="black")
+        self.tree.tag_configure('oddrow', background='white', foreground="black")
 
         self.tree.pack(pady=1, padx=1, fill='both', expand=True)
 


### PR DESCRIPTION
First of all thanks for the awesome project.

OSX dark mode seems to default to white text??? So it looks like this
<img width="937" alt="image" src="https://github.com/user-attachments/assets/96be5053-a1bb-47df-b374-94e9ebb02b80" />

So forcing the foreground you get this

<img width="807" alt="image" src="https://github.com/user-attachments/assets/41e1f555-03b5-4e38-ae55-8cc6ee793ef5" />
